### PR TITLE
Add support for copying the code snippet to the clipboard

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,10 @@
 import visit from 'unist-util-visit';
 import qs from 'query-string';
 
-module.exports = function gatsbyRemarkCodeTitles({ markdownAST }, { className: customClassName }) {
+module.exports = function gatsbyRemarkCodeTitles(
+  { markdownAST },
+  { className: customClassName, copy = false } = {}
+) {
   visit(markdownAST, 'code', (node, index) => {
     const [language, query] = (node.lang || '').split(':');
     const { title } = qs.parse(query);
@@ -10,12 +13,24 @@ module.exports = function gatsbyRemarkCodeTitles({ markdownAST }, { className: c
     }
 
     const className = ['gatsby-code-title'].concat(customClassName || []);
+    const copyFunction = `(function () { if ('clipboard' in navigator) {navigator.clipboard.writeText('${
+      node.value
+    }').then(function() {alert('Copied to clipboard')}, function() { alert('Error copying code to clipboard')})}})()`;
+
+    const button = `
+      <button type="button" class="gastsby-code-title-copy" alt="Copy to clipboard" onclick="${copyFunction}">
+        Copy
+      </button>
+      `;
 
     const titleNode = {
       type: 'html',
       value: `
-<div class="${className.join(' ').trim()}">${title}</div>
-      `.trim()
+    <div class="${className.join(' ').trim()}">
+      ${title}
+      ${copy ? button : ''}
+    </div>
+      `.trim(),
     };
 
     /*


### PR DESCRIPTION
I added support for copying the code snippet to the clipboard based on the suggestions in [this issue](https://github.com/gatsbyjs/gatsby/issues/5030).
Any feedback is welcome