### PR TITLE
Handle language strings with options in curly brackets

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,8 @@ module.exports = function gatsbyRemarkCodeTitles(
   visit(markdownAST, 'code', (node, index, parent) => {
     // If we have a space in the language string (e.g. `js{numberLines: true}:title=index.js`)
     // the string after the space is going to be set as the `meta` field
-    let nodeLang = node.meta ? node.lang + node.meta : node.lang || '';
+    // Reconstruct the string with the space
+    let nodeLang = node.meta ? node.lang + ' ' + node.meta : node.lang || '';
 
     // Extract the options between brackets {} (e.g. {numberLines: true}{1,6-10})
     let bracketOptions = extractOptions(nodeLang);

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,36 @@
 import visit from 'unist-util-visit';
 import qs from 'query-string';
 
+function extractOptions(lang) {
+  // Get the index of the first { and last } to extract the options
+  const start = lang.indexOf('{');
+  const end = lang.lastIndexOf('}');
+
+  if (start !== -1 && end !== -1) {
+    return lang.substring(start, end + 1);
+  }
+
+  return '';
+}
+
 module.exports = function gatsbyRemarkCodeTitles(
   { markdownAST },
   { className: customClassName } = {}
 ) {
   visit(markdownAST, 'code', (node, index, parent) => {
-    const [language, params] = (node.lang || '').split(':');
+    // If we have a space in the language string (e.g. `js{numberLines: true}:title=index.js`)
+    // the string after the space is going to be set as the `meta` field
+    let nodeLang = node.meta ? node.lang + node.meta : node.lang || '';
+
+    // Extract the options between brackets {} (e.g. {numberLines: true}{1,6-10})
+    let bracketOptions = extractOptions(nodeLang);
+
+    if (bracketOptions) {
+      // Remove the plugin options from the language string
+      nodeLang = nodeLang.replace(bracketOptions, '');
+    }
+
+    const [language, params] = nodeLang.split(':');
     const options = qs.parse(params);
     const { title, ...rest } = options;
     if (!title || !language) {
@@ -38,8 +62,14 @@ module.exports = function gatsbyRemarkCodeTitles(
 
     /*
      * Reset to just the language
+     *
+     * If we have a space in the language string (e.g. `js{numberLines: true}:title=index.js`)
+     * the meta field will contain the string after the space, we need to clear this field
+     * to prevent an inifinte loop caused by `:title` present in `node.meta`
+     * See: https://github.com/syntax-tree/mdast#code
      */
-    node.lang = language + newQuery;
+    node.lang = language + bracketOptions + newQuery;
+    node.meta = null;
   });
 
   return markdownAST;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -104,4 +104,35 @@ describe(`adding title`, () => {
     );
     expect(codeNode.lang).toBe(`js:clipboard=true`);
   });
+
+  test(`it adds the title and preserves the options between curly brackets`, () => {
+    const [original, updated] = setup(`
+      1. this is a list with an indented code block
+          \`\`\`js{1,4-6}{numberLines:true}:title=hello-world.js&clipboard=true
+          alert('hello world')
+          \`\`\`
+    `);
+    const [_, titleNode, codeNode] = updated.children[0].children[0].children;
+
+    expect(titleNode.value).toBe(
+      `<div class="gatsby-code-title">hello-world.js</div>`
+    );
+    expect(codeNode.lang).toBe(`js{1,4-6}{numberLines:true}:clipboard=true`);
+  });
+
+  test(`it adds the title and handles a language string with spaces`, () => {
+    // In this case `node.meta` will be set with the string after the space
+    const [original, updated] = setup(`
+      1. this is a list with an indented code block
+          \`\`\`js{1,4-6}{numberLines: true}:title=hello-world.js&clipboard=true
+          alert('hello world')
+          \`\`\`
+    `);
+    const [_, titleNode, codeNode] = updated.children[0].children[0].children;
+
+    expect(titleNode.value).toBe(
+      `<div class="gatsby-code-title">hello-world.js</div>`
+    );
+    expect(codeNode.lang).toBe(`js{1,4-6}{numberLines:true}:clipboard=true`);
+  });
 });

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -133,6 +133,21 @@ describe(`adding title`, () => {
     expect(titleNode.value).toBe(
       `<div class="gatsby-code-title">hello-world.js</div>`
     );
-    expect(codeNode.lang).toBe(`js{1,4-6}{numberLines:true}:clipboard=true`);
+    expect(codeNode.lang).toBe(`js{1,4-6}{numberLines: true}:clipboard=true`);
+  });
+
+  test(`it adds the title with spaces`, () => {
+    const [original, updated] = setup(`
+      1. this is a list with an indented code block
+          \`\`\`js:title=hello world (test).js&clipboard=true
+          alert('hello world')
+          \`\`\`
+    `);
+    const [_, titleNode, codeNode] = updated.children[0].children[0].children;
+
+    expect(titleNode.value).toBe(
+      `<div class="gatsby-code-title">hello world (test).js</div>`
+    );
+    expect(codeNode.lang).toBe(`js:clipboard=true`);
   });
 });


### PR DESCRIPTION
Hello,

This pull request aims to solve the problems caused by having line numbering and highlighting options for [gatsby-remark-prismjs](https://www.gatsbyjs.org/packages/gatsby-remark-prismjs/), for example:

````md
```js{numberLines: true}
```js{1,5-7}
````

The new code extracts all of the options inside the curly brackets `{}` and continues processing the new language string without these options then at the end we add them back to the language string stored as `node.lang`.

After this change we can add a title and use line numbering and highlighting at the same time.

**Update**: I didn't notice the issue #5 before this pull request, so I updated the code to preserve the spaces in the title when the language string is split into `node.lang` and `node.meta`.